### PR TITLE
add two GH actions

### DIFF
--- a/.github/workflows/check_jekyll_build.yml
+++ b/.github/workflows/check_jekyll_build.yml
@@ -1,0 +1,29 @@
+name: Check Jekyll Build
+on:
+  pull_request:
+    branches: [ gh-pages ]
+
+jobs:
+  jekyll_build:
+    name: Jekyll build of web pages
+    runs-on: ubuntu-latest
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # https://github.com/marketplace/actions/build-jekyll
+      - name: Build with Jekyll
+        uses: jerryjvl/jekyll-build-action@v1
+
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball
+        run: tar czf site.tar.gz ./_site/
+
+      # https://github.com/actions/upload-artifact
+      - name: Upload Website artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: Website
+          path: site.tar.gz

--- a/.github/workflows/jekyll-diff.yml
+++ b/.github/workflows/jekyll-diff.yml
@@ -1,0 +1,13 @@
+# https://github.com/David-Byrne/jekyll-diff-action
+
+name: Jekyll diff
+on: [push]
+
+jobs:
+  diff-site:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: David-Byrne/jekyll-diff-action@v1.2.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One will create a tarball with the full site for local inspection but we need to download and check it. I'm investigating a way to publish it somewhere so we can inspect it easily before the merge.

The other one would be helpful in https://github.com/ioos/ioos-metadata/pull/22 and https://github.com/ioos/ioos-metadata/pull/24 b/c we could see the image link and placement in the HTML diff generated.

Try to address https://github.com/ioos/ioos-documentation-jekyll-skeleton/issues/3