### PR TITLE
keep alive using GHA API instead of commits

### DIFF
--- a/.github/workflows/sync_theme.yml
+++ b/.github/workflows/sync_theme.yml
@@ -7,7 +7,7 @@ on:
   schedule:
      - cron: "00 14 * * *"
 
-  workflow_dispatch:
+  workflow_dispatch: null
 
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4
 
     - name: submodule checkout
       run: |
@@ -42,8 +42,9 @@ jobs:
   keepalive-job:
     name: Keepalive Workflow
     runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4
+      - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a # 2.0.1


### PR DESCRIPTION
This is an improvement on #44 b/c:

- Uses a feature of the GHA keep alive v2 that will use GHA API instead of a dummy commit. It is virtually the same as we clicking on the button.
- Use hashes for the GHA versions b/c it is safer, tagged releases can be modified in place. 